### PR TITLE
マイグレーションファイルのミス修正

### DIFF
--- a/db/migrate/20220602083210_devise_create_admins.rb
+++ b/db/migrate/20220602083210_devise_create_admins.rb
@@ -31,10 +31,7 @@ class DeviseCreateAdmins < ActiveRecord::Migration[6.1]
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
-      t.string :name
-      t.string :name_kana
-      t.string :user_name
-      t.boolean :is_deleted, default: false
+
 
 
       t.timestamps null: false

--- a/db/migrate/20220602083340_devise_create_users.rb
+++ b/db/migrate/20220602083340_devise_create_users.rb
@@ -31,6 +31,10 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
+      t.string :name
+      t.string :name_kana
+      t.string :user_name
+      t.boolean :is_deleted, default: false
 
 
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_03_004101) do
+ActiveRecord::Schema.define(version: 2022_06_03_014325) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -46,10 +46,6 @@ ActiveRecord::Schema.define(version: 2022_06_03_004101) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.string "name"
-    t.string "name_kana"
-    t.string "user_name"
-    t.boolean "is_deleted", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
@@ -64,6 +60,10 @@ ActiveRecord::Schema.define(version: 2022_06_03_004101) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
+    t.string "name_kana"
+    t.string "user_name"
+    t.boolean "is_deleted", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
- userモデルに入れるべきカラムをadminモデルに追加してしまったミスの修正
- nameカラム、name_kanaカラム、user_nameカラム、is_deletedカラムをadminから削除し、userへ追加