### PR TITLE
タグの区切りの変更、投稿に関するviewページの変更

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,6 +26,9 @@ class Post < ApplicationRecord
       @post = Post.all
     end
   end
+  
+  #タグの区切りを"#"に変更
+  ActsAsTaggableOn.delimiter = '#'
 
   private
   #投稿画像の枚数制限のエラーメッセージ

--- a/app/views/admin/posts/_index.html.erb
+++ b/app/views/admin/posts/_index.html.erb
@@ -1,0 +1,28 @@
+<table class="table">
+  <tbody>
+    <% posts.each do |post| %>
+      <tr>
+        <td>
+          <!--タイトル-->
+          <%= link_to post.title, admin_post_path(post) %>
+        </td>
+        <td>
+          <!--説明文-->
+          <%= post.body.truncate(5) %>
+        </td>
+        <td>
+          <!--タグ-->
+          <% post.tag_list.each do |tag| %>
+            <span class="badge badge-primary">
+              #<%= tag %>
+            </span>
+          <% end %>
+        </td>
+        <!--コメント数-->
+        <td>
+          コメント数：<%= post.post_comments.count %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,36 +1,8 @@
-
 <div class="container">
   <div class="row">
     <div class="col-12">
-        <h2>投稿一覧</h2>
-      <table class="table">
-        <tbody>
-          <% @posts.each do |post| %>
-            <tr>
-              <td>
-                <!--タイトル-->
-                <%= link_to post.title, admin_post_path(post) %>
-              </td>
-              <td>
-                <!--説明文-->
-                <%= post.body.truncate(5) %>
-              </td>
-              <td>
-                <!--タグ-->
-                <% post.tag_list.each do |tag| %>
-                  <span class="badge badge-primary">
-                    <%= tag %>
-                  </span>
-                <% end %>
-              </td>
-              <!--コメント数-->
-              <td>
-                コメント数：<%= post.post_comments.count %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <h2>投稿一覧</h2>
+      <%= render "admin/posts/index", posts: @posts %>
     </div>
   </div>
   <div class="row">

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -28,7 +28,7 @@
           <div>
             <% @post.tag_list.each do |tag| %>
               <span class="badge badge-primary">
-                <%= tag %>
+                #<%= tag %>
               </span>
             <% end %>
           </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -21,9 +21,9 @@
       <!--@userが投稿をしているかを確認-->
       <% if @user.posts.exists? %>
         <!--存在している場合、@userの投稿一覧表示-->
-        <% @posts.each do |post| %>
-          <%= post.title %>
-        <% end %>
+        <div class="row">
+          <%= render "admin/posts/index", posts: @posts %>
+        </div>
         <!--ページネーション-->
         <div class="row">
           <div class="mx-auto">

--- a/app/views/public/posts/_form.html.erb
+++ b/app/views/public/posts/_form.html.erb
@@ -17,7 +17,7 @@
 
 <div class="form-group">
   <%= f.label :tag_list, "タグ" %>
-  <%= f.text_field :tag_list, value: post.tag_list.join(','), class: "form-control", placeholder: ",で区切ると複数投稿できます" %>
+  <%= f.text_field :tag_list, value: post.tag_list.join('#'), class: "form-control", placeholder: "#で区切ると複数追加できます" %>
 </div>
 
 <div class="form-group">

--- a/app/views/public/posts/_index.html.erb
+++ b/app/views/public/posts/_index.html.erb
@@ -15,7 +15,7 @@
           <% post.tag_list.each do |tag| %>
             <span class="badge badge-primary">
               <!--tagを押すとtagがついた投稿を一覧で表示される-->
-              <%= link_to tag, posts_path(tag_name: tag), class: "text-white" %>
+              #<%= link_to tag, posts_path(tag_name: tag), class: "text-white" %>
             </span>
           <% end %>
         </td>

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-12">
       <% if params[:tag_name] %>
-        <h2><%= "#{params[:tag_name]}" %>一覧</h2>
+        <h2>#<%= "#{params[:tag_name]}" %>一覧</h2>
       <% else %>
         <h2>投稿一覧</h2>
       <% end %>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -29,7 +29,7 @@
             <% @post.tag_list.each do |tag| %>
               <span class="badge badge-primary">
                 <!--tagを押すとtagがついた投稿を一覧で表示される-->
-                <%= link_to tag, posts_path(tag_name: tag), class: "text-white" %>
+                #<%= link_to tag, posts_path(tag_name: tag), class: "text-white" %>
               </span>
             <% end %>
           </div>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -26,11 +26,11 @@
   <div class="row py-4">
     <div class="col-12 mx-auto">
       <!--@userが投稿をしているかを確認-->
-      <% if @user.posts.exists? %>
+      <% if @posts.exists? %>
         <!--存在している場合、@userの投稿一覧表示-->
-        <% @posts.each do |post| %>
-          <%= post.title %>
-        <% end %>
+        <div class="row">
+          <%= render "public/posts/index", posts: @posts %>
+        </div>
         <!--ページネーション-->
         <div class="row">
           <div class="mx-auto">


### PR DESCRIPTION
- 新規投稿と、投稿編集の際に区切りを","から"#"に変更
- 投稿に関するviewページのタグの表記をわかりやすくするためにタグの前に#を追加
- admin側に部分テンプレートを追加