### PR TITLE
レイアウト変更1回目

### DIFF
--- a/app/assets/stylesheets/slick-theme.scss
+++ b/app/assets/stylesheets/slick-theme.scss
@@ -39,25 +39,6 @@ $slick-opacity-not-active: 0.25 !default;
     }
 }
 
-/* Slider */
-
-.slick-list {
-    .slick-loading & {
-        background: #fff slick-image-url("ajax-loader.gif") center center no-repeat;
-    }
-}
-
-/* Icons */
-@if $slick-font-family == "slick" {
-    @font-face {
-        font-family: "slick";
-        src: slick-font-url("slick.eot");
-        src: slick-font-url("slick.eot?#iefix") format("embedded-opentype"), slick-font-url("slick.woff") format("woff"), slick-font-url("slick.ttf") format("truetype"), slick-font-url("slick.svg#slick") format("svg");
-        font-weight: normal;
-        font-style: normal;
-    }
-}
-
 /* Arrows */
 
 .slick-prev,
@@ -177,7 +158,7 @@ $slick-opacity-not-active: 0.25 !default;
                 width: 20px;
                 height: 20px;
                 font-family: $slick-font-family;
-                font-size: $slick-dot-size;
+                font-size: 50px;
                 line-height: 20px;
                 text-align: center;
                 color: $slick-dot-color;

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -12,12 +12,13 @@ class Public::UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
+      flash[:notice] = "ユーザー情報を更新しました"
       redirect_to user_path(@user)
     else
       render "edit"
     end
   end
-  
+
   #いいねした投稿を一覧表示させる
   def favorites
     @user = User.find(params[:id])
@@ -29,7 +30,7 @@ class Public::UsersController < ApplicationController
   #退会画面の表示
   def quit
   end
-  
+
   #退会機能
   def withdraw
     #ユーザーステータスをfalseからtrueへ更新
@@ -45,7 +46,7 @@ class Public::UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :name_kana, :user_name, :profile_image, :email )
   end
-  
+
   #本人しかユーザー情報を編集できないようにするためのアクション
   def ensure_correct_user
     @user = User.find(params[:id])

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,3 +19,19 @@ Turbolinks.start()
 ActiveStorage.start()
 
 window.$ = window.jQuery = require('jquery');
+global.$ = global.jQuery = require('jquery');
+
+//ハンバーガーメニュー
+/* global $*/
+$(document).on('turbolinks:load', function() {
+	$('.menu-button').click(function () {
+		$(this).toggleClass('active');
+		$('.open-menu-bg').fadeToggle();
+		$('nav').toggleClass('open');
+	})
+	$('.open-menu-bg').click(function () {
+		$(this).fadeOut();
+		$('.menu-button').removeClass('active');
+		$('nav').removeClass('open');
+	});
+})

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,11 +1,6 @@
 @import '~bootstrap/scss/bootstrap';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 
-//画像の下のドットの大きさ変更
-.slick-dots li button:before{
-	font-size: 50px!important;
-}
-
 //投稿画像が一枚の時はドットを非表示
 .slick-dots > li:first-child:last-child {
     display: none;
@@ -19,70 +14,231 @@
   }
 }
 
-//遷移ボタンのcssここから
-.select_btn{
+//地図のスタイル
+#map {
+  height: 500px;
+  width: 100%;
+}
+
+//遷移ボタンのスタイルここから
+.select-button {
+  width: 100%;
   height: 50px;
   background-color: white;
 }
 
-.select_btn a{
-  text-decoration: none;
+.indicator {
+  height: 50px;
+  width: 500px;
+  margin: 0 auto;
+  display: flex;
+
 }
 
-.indicator{
-  display: flex;
-  flex-flow: column;
-  text-align: center;
+.select-button a {
+  text-decoration: none;
   color: black;
 }
 
-.icon{
+.buttons {
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.icon {
   font-size: 30px;
   transition: 0.8s;
 }
 
-.indicator:hover .icon{
+.buttons:hover .icon {
   transform: translateY(-50px);
   font-size: 50px;
 }
 
-.indicator strong{
+.buttons strong {
   opacity: 0;
   position: absolute;
-  top: 0;
-  bottom: 0;
   right: 0;
   left: 0;
   transition: 0.8s;
 }
 
-.indicator:hover strong{
+.buttons:hover strong {
   opacity: 1;
   transform: translateY(5px);
 }
 //ここまで
 
-footer{
+footer {
   padding-bottom: 100px;
 }
 
-//レスポンシブ対応
-@media screen and (max-width: 480px){
-  .indicator strong{
+//ハンバーガーメニューのスタイルここから
+.hamburger-menu {
+  //メニューボタンのスタイル
+  .menu-button {
+    display: block;
+    padding: 0;
+    width: 40px;
+    height: 25px;
+    position: fixed;
+    background: none;
+    border: none;
+    text-align: center;
+    color: black;
+    top: 25px;
+    right: 20px;
+    z-index: 1001;
+    outline: none;
+  }
+
+  .menu-button .menu-bar {
+    display: block;
+    width: 40px;
+    height: 2px;
+    transition: 0.2s;
+    transform-origin: 0% 0%;
+    position: absolute;
+    left: 0;
+    background-color: black;
+  }
+
+  .menu-button .menu-bar1 {
+    top: 0;
+  }
+
+  .menu-button .menu-bar2 {
+    top: 50%;
+  }
+
+  .menu-button .menu-bar3 {
+    top: 100%;
+  }
+
+  .menu-text {
+    width: 100%;
+    position: absolute;
+    bottom: -20px;
+    left: 0;
+    text-align: center;
+    font-size: 10px;
+  }
+
+  .close-menu {
     display: none;
   }
 
-  .select_btn{
-    height: 50px;
+  .menu-button.active .menu-bar {
+    width: 35px;
+    left: 8px;
   }
 
-  .icon{
+  .menu-button.active .menu-bar1 {
+    transform: rotate(45deg) translateY(-50%);
+    top: 0px
+  }
+
+  .menu-button.active .menu-bar2 {
+    opacity: 0;
+  }
+
+  .menu-button.active .menu-bar3 {
+    transform: rotate(-45deg) translateY(-50%);
+    top: calc(100% - 0px)
+  }
+
+  .menu-button.active .open-menu {
+    display: none;
+  }
+
+  .menu-button.active .close-menu {
+    display: block;
+  }
+
+  //ナビゲーションメニューのスタイル
+  a {
+    text-decoration: none;
+    color: black;
+  }
+
+  .nav-menu {
+    padding: 100px 20px;
+  }
+
+  li{
+    margin-bottom: 20px;
+    text-align: center;
+  }
+
+  .open-menu-bg {
+		width: 100%;
+		height: 100%;
+		position: fixed;
+		z-index: 999;
+		background-color: rgba(51, 51, 51, 0.5);
+		display: none;
+		top: 0;
+		left: 0;
+	}
+
+	.nav-wrapper {
+		width: 200px;
+		height: 100%;
+		transition: 0.2s;
+		transform: translate(200px);
+		position: fixed;
+		top: 0;
+		right: 0;
+		z-index: 1000;
+		background-color: #FFF;
+		&.open {
+			transform: translate(0);
+		}
+	}
+}
+//ここまで
+
+
+//レスポンシブ対応
+@media screen and (max-width: 480px){
+  .buttons strong {
+    display: none;
+  }
+
+  .indicator {
+    width: 100%;
+  }
+
+  .icon {
     font-size: 20px;
+  }
+
+  .search-form button{
+    display: none;
+  }
+
+  .hamburger-menu {
+    .menu-button {
+      top: 100px;
+    }
+
+    .nav-menu {
+      padding: 175px 20px;
+    }
   }
 }
 
-@media screen and (max-width: 285px){
-  .search-form button{
-    display: none;
+//検索フォームとハンバーガーメニューが被らないように調整
+@media screen and (max-width: 401px){
+  .hamburger-menu {
+    .menu-button {
+      top: 25px;
+    }
+    .nav-menu {
+      padding: 100px 20px;
+    }
   }
 }

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,26 +1,6 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="container">
+  <div class="w-75 mx-auto">
+    <h2 class="my-4">管理者ログイン</h2>
+    <%= render "public/sessions/form", model: @admin, url: admin_session_path %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "admin/shared/links" %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,7 +6,7 @@
     <% unless admin_signed_in? %>
       <div class="search-form">
         <%= form_with url: search_path, method: :get do |f| %>
-          <div class="border rounded-pill p-1">
+          <div class="border rounded-pill p-1 mr-3 mr-sm-0">
             <%= f.text_field :word, placeholder: "投稿を検索", style: "border: 0; outline: 0;" %>
             <%= f.button :type => "submit", style: "border-style: none; background: none;" do %>
               <i class="fas fa-search"></i>
@@ -16,38 +16,50 @@
       </div>
     <% end %>
     <!--ハンバーガーメニュー-->
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <!--ナビゲーションメニュー-->
-    <div class="collapse navbar-collapse" id="navbarNavDropdown">
-      <ul class="navbar-nav ml-auto">
-        <% if user_signed_in? %>
-          <!--ログインしている場合の表示-->
-          <li class="nav-item">
-            <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
-          </li>
-        <% elsif admin_signed_in? %>
-          <!--管理者がログインしている場合の表示-->
-          <li class="nav-item">
-            <%= link_to "ユーザー一覧", admin_users_path %>
-          </li>
-          <li class="nav-item">
-            <%= link_to "投稿一覧", admin_posts_path %>
-          </li>
-          <li class="nav-item">
-            <%= link_to "ログアウト", destroy_admin_session_path, method: :delete %>
-          </li>
-        <% else %>
-          <!--ログインしていない場合の表示-->
-          <li class="nav-item">
-            <%= link_to "新規登録", new_user_registration_path %>
-          </li>
-          <li class="nav-item">
-            <%= link_to "ログイン", new_user_session_path %>
-          </li>
-        <% end %>
-      </ul>
+    <div class="hamburger-menu">
+      <!--ハンバーガーメニューを開いた時の背景-->
+      <div class="open-menu-bg"></div>
+      <!--メニューボタン-->
+      <button type="button" class="menu-button">
+        <span class="menu-bar menu-bar1"></span>
+        <span class="menu-bar menu-bar2"></span>
+        <span class="menu-bar menu-bar3"></span>
+        <span class="open-menu menu-text">MENU</span>
+        <span class="close-menu menu-text">CLOSE</span>
+      </button>
+      <!--ナビゲーションメニュー-->
+      <nav class="nav-wrapper">
+        <ul class="nav-menu navbar-nav">
+          <% if user_signed_in? %>
+            <!--ログインしている場合の表示-->
+            <li class="nav-item">
+              <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+            </li>
+          <% elsif admin_signed_in? %>
+            <!--管理者がログインしている場合の表示-->
+            <li class="nav-item">
+              <%= link_to "ユーザー一覧", admin_users_path %>
+            </li>
+            <li class="nav-item">
+              <%= link_to "投稿一覧", admin_posts_path %>
+            </li>
+            <li class="nav-item">
+              <%= link_to "ログアウト", destroy_admin_session_path, method: :delete %>
+            </li>
+          <% else %>
+            <!--ログインしていない場合の表示-->
+            <li class="nav-item">
+              <%= link_to "投稿一覧", posts_path %>
+            </li>
+            <li class="nav-item">
+              <%= link_to "新規登録", new_user_registration_path %>
+            </li>
+            <li class="nav-item">
+              <%= link_to "ログイン", new_user_session_path %>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
     </div>
   </div>
 </nav>

--- a/app/views/layouts/_select_btn.html.erb
+++ b/app/views/layouts/_select_btn.html.erb
@@ -1,34 +1,28 @@
-<div class="row fixed-bottom d-flex mx-5 select_btn">
-  <div class="col-3">
-    <%= link_to posts_path do %>
-      <div class="indicator">
+<div class="fixed-bottom select-button">
+  <div class="indicator">
+    <div class="col-3 buttons">
+      <%= link_to posts_path do %>
         <i class="fa-solid fa-house icon" ></i>
         <strong>投稿一覧</strong>
-      </div>
-    <% end %>
-  </div>
-  <div class="col-3">
-    <%= link_to new_post_path do %>
-      <div class="indicator">
+      <% end %>
+    </div>
+    <div class="col-3 buttons">
+      <%= link_to new_post_path do %>
         <i class="fa-solid fa-circle-plus icon"></i>
         <strong>新規投稿</strong>
-      </div>
-    <% end %>
-  </div>
-  <div class="col-3">
-    <%= link_to favorites_user_path(current_user) do %>
-      <div class="indicator">
+      <% end %>
+    </div>
+    <div class="col-3 buttons">
+      <%= link_to favorites_user_path(current_user) do %>
         <i class="fa-solid fa-heart icon"></i>
         <strong>いいねリスト</strong>
-      </div>
-    <% end %>
-  </div>
-  <div class="col-3">
-    <%= link_to user_path(current_user) do %>
-      <div class="indicator">
+      <% end %>
+    </div>
+    <div class="col-3 buttons">
+      <%= link_to user_path(current_user) do %>
         <i class="fa-solid fa-user icon"></i>
         <strong>マイページ</strong>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
         <%= render "layouts/select_btn" %>
       <% end %>
     </main>
-    <footer class="py-4 border-top text-center" style="margin-bottom:200px;">
+    <footer class="py-4 mt-5 border-top text-center" style="margin-bottom:200px;">
       <strong>jimopot</strong>
     </footer>
   </body>

--- a/app/views/public/posts/edit.html.erb
+++ b/app/views/public/posts/edit.html.erb
@@ -13,77 +13,71 @@
         </div>
 
         <div id='map'></div>
-        <style>
-        #map {
-          height: 500px;
-          width: 100%;
-        }
-        </style>
-        <!-- js部分 -->
-        <script>
-        //初期マップの設定
-          let map
-          let marker
-          function initMap(){
-            geocoder = new google.maps.Geocoder()
-
-            map = new google.maps.Map(document.getElementById('map'), {
-              center:  {lat: <%= @post.latitude %>, lng: <%= @post.longitude %>},
-              zoom: 15,
-            });
-
-            //検索フォーム
-            const input = document.getElementById("address");
-            const searchBox = new google.maps.places.SearchBox(input);
-
-            map.addListener("bounds_changed", () => {
-              searchBox.setBounds(map.getBounds());
-            });
-          }
-          //検索後のマップ作成
-          let geocoder
-          let aft
-          function codeAddress(){
-            let inputAddress = document.getElementById('address').value;
-            geocoder.geocode( { 'address': inputAddress}, function(results, status) {
-              if (status == 'OK') {
-                  //マーカーが複数できないようにする
-                  if (aft == true){
-                      marker.setMap(null);
-                  }
-
-                  //新しくマーカーを作成する
-                  map.setCenter(results[0].geometry.location);
-                      marker = new google.maps.Marker({
-                      map: map,
-                      position: results[0].geometry.location,
-                      draggable: true // ドラッグ可能にする
-                  });
-
-                  //二度目以降か判断
-                  aft = true
-
-                  //検索した時に緯度経度を入力する
-                  document.getElementById('lat').value = results[0].geometry.location.lat();
-                  document.getElementById('lng').value = results[0].geometry.location.lng();
-
-                  // マーカーのドロップ（ドラッグ終了）時のイベント
-                  google.maps.event.addListener( marker, 'dragend', function(ev){
-                      // イベントの引数evの、プロパティ.latLngが緯度経度
-                      document.getElementById('lat').value = ev.latLng.lat();
-                      document.getElementById('lng').value = ev.latLng.lng();
-                  });
-              } else {
-                alert('該当する結果がありませんでした');
-              }
-            });
-          }
-
-        </script>
-        <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&callback=initMap&libraries=places" async defer></script>
+        
         <%= f.submit "更新", class: "btn btn-primary" %><%= link_to "戻る", post_path(@post), class: "btn btn-outline-secondary" %>
       <% end %>
 
     </div>
   </div>
 </div>
+<!-- js部分 -->
+<script>
+  //初期マップの設定
+  let map
+  let marker
+  function initMap(){
+    geocoder = new google.maps.Geocoder()
+
+    map = new google.maps.Map(document.getElementById('map'), {
+      center:  {lat: <%= @post.latitude %>, lng: <%= @post.longitude %>},
+      zoom: 15,
+    });
+
+    //検索フォーム
+    const input = document.getElementById("address");
+    const searchBox = new google.maps.places.SearchBox(input);
+
+    map.addListener("bounds_changed", () => {
+      searchBox.setBounds(map.getBounds());
+    });
+  }
+  //検索後のマップ作成
+  let geocoder
+  let aft
+  function codeAddress(){
+    let inputAddress = document.getElementById('address').value;
+    geocoder.geocode( { 'address': inputAddress}, function(results, status) {
+      if (status == 'OK') {
+          //マーカーが複数できないようにする
+          if (aft == true){
+              marker.setMap(null);
+          }
+
+          //新しくマーカーを作成する
+          map.setCenter(results[0].geometry.location);
+              marker = new google.maps.Marker({
+              map: map,
+              position: results[0].geometry.location,
+              draggable: true // ドラッグ可能にする
+          });
+
+          //二度目以降か判断
+          aft = true
+
+          //検索した時に緯度経度を入力する
+          document.getElementById('lat').value = results[0].geometry.location.lat();
+          document.getElementById('lng').value = results[0].geometry.location.lng();
+
+          // マーカーのドロップ（ドラッグ終了）時のイベント
+          google.maps.event.addListener( marker, 'dragend', function(ev){
+              // イベントの引数evの、プロパティ.latLngが緯度経度
+              document.getElementById('lat').value = ev.latLng.lat();
+              document.getElementById('lng').value = ev.latLng.lng();
+          });
+      } else {
+        alert('該当する結果がありませんでした');
+      }
+    });
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&callback=initMap&libraries=places" async defer></script>

--- a/app/views/public/posts/new.html.erb
+++ b/app/views/public/posts/new.html.erb
@@ -1,90 +1,89 @@
 <div class="container">
   <div class="row">
     <div class="col-10 mx-auto">
-      <h2>新規投稿</h2>
       <%= form_with model: @post do |f| %>
+        <h2>新規投稿</h2>
+        <div class="form-group">
+          
+        </div>
+        <%= f.submit "投稿", class: "btn btn-primary float-right" %>
+
         <%= render "form", post: @post, f: f %>
 
         <%= f.label :map, "地図" %>
-        <!--地図の表示-->
+        <!--地図検索フォーム-->
         <div class="d-flex mb-4">
           <input id="address" class="form-control" type="text" placeholder="Search Box"/>
           <input type="button" value="検索" onclick="codeAddress()">
         </div>
-
+        <!--地図の表示-->
         <div id='map'></div>
-        <style>
-        #map {
-          height: 500px;
-          width: 100%;
-        }
-        </style>
-        <!-- js部分 -->
-        <script>
-        //初期マップの設定
-        let map
-        let marker
-        function initMap(){
-          geocoder = new google.maps.Geocoder()
 
-          map = new google.maps.Map(document.getElementById('map'), {
-            center:  {lat:35.710006892117, lng:139.81081025188},  //東京スカイツリー
-            zoom: 15,
-          });
-
-          //検索フォーム
-          const input = document.getElementById("address");
-          const searchBox = new google.maps.places.SearchBox(input);
-
-          map.addListener("bounds_changed", () => {
-            searchBox.setBounds(map.getBounds());
-          });
-        }
-
-        //検索後のマップ作成
-        let geocoder
-        let aft
-        function codeAddress(){
-          let inputAddress = document.getElementById('address').value;
-          geocoder.geocode( { 'address': inputAddress}, function(results, status) {
-            if (status == 'OK') {
-                //マーカーが複数できないようにする
-                if (aft == true){
-                    marker.setMap(null);
-                }
-
-                //新しくマーカーを作成する
-                map.setCenter(results[0].geometry.location);
-                    marker = new google.maps.Marker({
-                    map: map,
-                    position: results[0].geometry.location,
-                    draggable: true // ドラッグ可能にする
-                });
-
-                //二度目以降か判断
-                aft = true
-
-                //検索した時に緯度経度を入力する
-                document.getElementById('lat').value = results[0].geometry.location.lat();
-                document.getElementById('lng').value = results[0].geometry.location.lng();
-
-                // マーカーのドロップ（ドラッグ終了）時のイベント
-                google.maps.event.addListener( marker, 'dragend', function(ev){
-                    // イベントの引数evの、プロパティ.latLngが緯度経度
-                    document.getElementById('lat').value = ev.latLng.lat();
-                    document.getElementById('lng').value = ev.latLng.lng();
-                });
-            } else {
-              alert('該当する結果がありませんでした');
-            }
-          });
-        }
-
-        </script>
-        <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&callback=initMap&libraries=places" async defer></script>
-
-        <%= f.submit "投稿", class: "btn btn-primary" %>
       <% end %>
     </div>
   </div>
 </div>
+
+<!-- js部分 -->
+<script>
+  //初期マップの設定
+  let map
+  let marker
+  function initMap(){
+    geocoder = new google.maps.Geocoder()
+
+    map = new google.maps.Map(document.getElementById('map'), {
+      center:  {lat:35.710006892117, lng:139.81081025188},  //東京スカイツリー
+      zoom: 15,
+    });
+
+    //検索フォーム
+    const input = document.getElementById("address");
+    const searchBox = new google.maps.places.SearchBox(input);
+
+    map.addListener("bounds_changed", () => {
+      searchBox.setBounds(map.getBounds());
+    });
+  }
+
+  //検索後のマップ作成
+  let geocoder
+  let aft
+  function codeAddress(){
+    let inputAddress = document.getElementById('address').value;
+    geocoder.geocode( { 'address': inputAddress}, function(results, status) {
+      if (status == 'OK') {
+          //マーカーが複数できないようにする
+          if (aft == true){
+              marker.setMap(null);
+          }
+
+          //新しくマーカーを作成する
+          map.setCenter(results[0].geometry.location);
+              marker = new google.maps.Marker({
+              map: map,
+              position: results[0].geometry.location,
+              draggable: true // ドラッグ可能にする
+          });
+
+          //二度目以降か判断
+          aft = true
+
+          //検索した時に緯度経度を入力する
+          document.getElementById('lat').value = results[0].geometry.location.lat();
+          document.getElementById('lng').value = results[0].geometry.location.lng();
+
+          // マーカーのドロップ（ドラッグ終了）時のイベント
+          google.maps.event.addListener( marker, 'dragend', function(ev){
+              // イベントの引数evの、プロパティ.latLngが緯度経度
+              document.getElementById('lat').value = ev.latLng.lat();
+              document.getElementById('lng').value = ev.latLng.lng();
+          });
+      } else {
+        alert('該当する結果がありませんでした');
+      }
+    });
+  }
+
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&callback=initMap&libraries=places" async defer></script>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -13,7 +13,7 @@
           <!--投稿画像、複数投稿されている時はスライドで画像を表示させる-->
           <div class="slick mx-auto" style="max-width:800px;">
             <% @post.post_images.each do |image| %>
-              <%= image_tag image.variant(resize_to_fill: [800, 500]) %>
+              <%= image_tag image.variant(resize_to_fill: [800, 650]) %>
             <% end %>
           </div>
           <!--タイトル-->
@@ -34,41 +34,14 @@
             <% end %>
           </div>
 
-          <!--地図の表示-->
-          <div id='map' style="height:500px; width:100%;"></div>
-
-          <!-- js部分 -->
-          <script>
-            //複数画像が投稿されている時の画像のスライド表示
-            $(document).on('turbolinks:load', function() {
-              $('.slick').slick({
-                dots: true,
-                arrows: false,
-              })
-            });
-
-            //地図表示
-            let map
-            let marker
-            function initMap(){
-              geocoder = new google.maps.Geocoder()
-
-              map = new google.maps.Map(document.getElementById('map'), {
-                center:  {lat: <%= @post.latitude %>, lng: <%= @post.longitude %>},
-                zoom: 15,
-              });
-
-               marker = new google.maps.Marker({
-                position:  {lat: <%= @post.latitude %>, lng: <%= @post.longitude %>},
-                map: map
-              });
-            }
-          </script>
-          <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&callback=initMap&libraries=places" async defer></script>
           <!--いいねボタン-->
           <div id="favorite-<%= @post.id %>">
             <%= render "public/favorites/favorite_btn", post: @post %>
           </div>
+
+          <!--地図の表示-->
+          <div id='map'></div>
+
           <!--コメント数-->
           <div class="comment-count">
             <%= @post.post_comments.count %> コメント
@@ -96,3 +69,31 @@
     </div>
   </div>
 </div>
+<!-- js部分 -->
+<script>
+  //複数画像が投稿されている時の画像のスライド表示
+  $(document).on('turbolinks:load', function() {
+    $('.slick').slick({
+      dots: true,
+      arrows: false,
+    })
+  });
+
+  //地図表示
+  let map
+  let marker
+  function initMap(){
+    geocoder = new google.maps.Geocoder()
+
+    map = new google.maps.Map(document.getElementById('map'), {
+      center:  {lat: <%= @post.latitude %>, lng: <%= @post.longitude %>},
+      zoom: 15,
+    });
+
+     marker = new google.maps.Marker({
+      position:  {lat: <%= @post.latitude %>, lng: <%= @post.longitude %>},
+      map: map
+    });
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&callback=initMap&libraries=places" async defer></script>

--- a/app/views/public/registrations/_info.html.erb
+++ b/app/views/public/registrations/_info.html.erb
@@ -1,24 +1,24 @@
-  <div class="form-group row">
-    <%= f.label :name, "名前" %>
-    <%= f.text_field :name, autofocus: true, class: "form-control name" %>
+  <div class="form-group mx-auto">
+    <%= f.label :name, class: "col-12 pl-md-0 mx-md-auto" %>
+    <%= f.text_field :name, autofocus: true, class: "col-12  mx-auto form-control name" %>
   </div>
 
-  <div class="form-group row">
-    <%= f.label :name_kana, "フリガナ" %>
-    <%= f.text_field :name_kana, class: "form-control name_kana" %>
+  <div class="form-group mx-auto">
+    <%= f.label :name_kana, class: "col-12  pl-md-0 mx-md-auto" %>
+    <%= f.text_field :name_kana, class: "col-12 mx-auto form-control name_kana" %>
   </div>
 
-  <div class="form-group row">
-    <%= f.label :profile_image, "プロフィール画像" %>
-    <%= f.file_field :profile_image, accept: "image/*", class: "form-control-file proflie_image" %>
+  <div class="form-group mx-auto">
+    <%= f.label :profile_image, class: "col-12  pl-md-0 mx-md-auto" %>
+    <%= f.file_field :profile_image, accept: "image/*", class: " col-12 mx-auto pl-0 form-control-file proflie_image" %>
   </div>
 
-  <div class="form-group row">
-    <%= f.label :user_name, "ユーザーネーム" %>
-    <%= f.text_field :user_name, class: "form-control user_name" %>
+  <div class="form-group mx-auto">
+    <%= f.label :user_name, class: "col-12  pl-md-0 mx-md-auto" %>
+    <%= f.text_field :user_name, class: "col-12  mx-auto form-control user_name" %>
   </div>
 
-  <div class="form-group row">
-    <%= f.label :email, "メールアドレス" %>
-    <%= f.email_field :email, class: "form-control email" %>
+  <div class="form-group mx-auto">
+    <%= f.label :email, class: "col-12  pl-md-0 mx-md-auto" %>
+    <%= f.email_field :email, class: "col-12  mx-auto form-control email" %>
   </div>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,29 +1,20 @@
 <div class="container">
-  <h2>新規登録</h2>
-
-  <%= form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user'  do |f| %>
-    <%= render "layouts/error_messages", model: @user %>
-
-    <%= render "public/registrations/info", f: f %>
-
-    <div class="form-group row">
-      <%= f.label :password, "パスワード" %>
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> 文字以上)</em>
-      <% end %><br />
-      <%= f.password_field :password, autocomplete: "new-password", class: "form-control password" %>
-    </div>
-
-    <div class="form-group row">
-      <%= f.label :password_confirmation, "パスワード(確認用)" %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control password_confirmation" %>
-    </div>
-
-    <div class="actions">
-      <%= f.submit "登録" %>
-    </div>
-  <% end %>
-
-  <%= render "public/shared/links" %>
-
+  <div class="mx-auto col-10 col-md-7">
+    <h2 class="my-4">新規登録</h2>
+    <%= form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user'  do |f| %>
+      <%= render "layouts/error_messages", model: @user %>
+      <%= render "public/registrations/info", f: f %>
+      <div class="form-group mx-auto">
+        <%= f.label :password, "パスワード(6文字以上)", class: "col-12  pl-md-0 mx-md-auto" %>
+        <%= f.password_field :password, autocomplete: "new-password", class: "col-12  mx-auto form-control password" %>
+      </div>
+      <div class="form-group mx-auto">
+        <%= f.label :password_confirmation, class: "col-12  pl-md-0 mx-md-auto" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "col-12  mx-auto form-control password_confirmation" %>
+      </div>
+      <div class="form-group text-center py-4">
+        <%= f.submit "登録", class: "col-5 btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/public/sessions/_form.html.erb
+++ b/app/views/public/sessions/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with model: model, url: url do |f| %>
+  <% if alert %>
+    <p class="alert alert-warning text-center"><%= alert %></p>
+  <% end %>
+  <div class="form-group row mx-auto my-5">
+    <%= f.label :email, class: "col-12 col-md-3 pl-md-0 mx-md-auto" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "col-12 col-md-8 mx-auto form-control email" %>
+  </div>
+  <div class="form-group row mx-auto mb-5">
+    <%= f.label :password, class: "col-12 col-md-3 pl-md-0 mx-md-auto" %>
+    <%= f.password_field :password, autocomplete: "current-password", class: "col-12 col-md-8 mx-auto form-control password" %>
+  </div>
+  <div class="form-group text-center pb-5">
+    <%= f.submit "ログイン", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,29 +1,6 @@
-<h2>Log in</h2>
-
-<%= form_with model: @user, url: user_session_path do |f| %>
-  <% if alert %>
-    <p class="alert alert-warning"><%= alert %></p>
-  <% end %>
-  <div class="field">
-    <%= f.label :email, "メールアドレス" %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="container">
+  <div class="w-75 mx-auto">
+    <h2 class="my-4">ログイン</h2>
+    <%= render "public/sessions/form", model: @user, url: user_session_path %>
   </div>
-
-  <div class="field">
-    <%= f.label :password, "パスワード" %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "public/shared/links" %>
+</div>

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -1,15 +1,13 @@
 <div class="container">
-  <div class="row">
-    <div class="col-6 mx-auto">
-      <h2>プロフィール編集</h2>
-      <%= form_with model: @user, url: user_path(@user), method: :patch do |f| %>
-        <%= render 'layouts/error_messages', model: @user %>
-        <%= render "public/registrations/info", f: f %>
-        <div class="row justify-content-center mt-4">
-          <%= f.submit "更新", class: "col-3 btn btn-primary mr-5" %>
-          <%= link_to "退会する", quit_path, class: "btn btn-outline-danger" %>
-        </div>
-      <% end %>
-    </div>
+  <div class="mx-auto col-10 col-md-7">
+    <h2 class="my-4">プロフィール編集</h2>
+    <%= form_with model: @user, url: user_path(@user), method: :patch do |f| %>
+      <%= render 'layouts/error_messages', model: @user %>
+      <%= render "public/registrations/info", f: f %>
+      <div class="form-group text-center py-md-4">
+        <%= f.submit "更新", class: "col-5 btn btn-primary m-1 m-md-4" %>
+        <%= link_to "退会", quit_path, class: "btn btn-outline-danger m-1 m-md-4" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,13 @@ ja:
         name_kana: フリガナ
         user_name: ユーザーネーム
         email: メールアドレス
+        profile_image: プロフィール画像
+        password: パスワード
+        encrypted_password: パスワード
+        password_confirmation: パスワード(確認用)
+      admin:
+        email: メールアドレス
+        password: パスワード
         encrypted_password: パスワード
       post:
         title: タイトル


### PR DESCRIPTION
- ログイン画面、新規登録画面、プロフィール編集画面のレイアウト変更
- ログイン画面に部分テンプレート追加
- ハンバーガーメニューをbootstrapのものからcssとjavascirptで動作するように変更
- 不必要な記述の削除
- ユーザー情報更新時のフラッシュメッセージ追加
- 画面遷移ボタンのレイアウト変更